### PR TITLE
removed unused import of "get_current_site()"

### DIFF
--- a/regex_redirects/middleware.py
+++ b/regex_redirects/middleware.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from .models import Redirect
-from django.contrib.sites.models import get_current_site
 from django.core.exceptions import ImproperlyConfigured
 from django import http
 


### PR DESCRIPTION
After that, regex_redirect can be used with Django 1.9. You should consider a new release.