### PR TITLE
Fix compatability with MySQL/MariaDB (issue #16):

### DIFF
--- a/regex_redirects/migrations/0002_auto_20151217_1938.py
+++ b/regex_redirects/migrations/0002_auto_20151217_1938.py
@@ -19,6 +19,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='redirect',
             name='old_path',
-            field=models.CharField(help_text="This should be an absolute path, excluding the domain name. Example: '/events/search/'.", max_length=2000, verbose_name='redirect from', db_index=True),
+            field=models.CharField(help_text="This should be an absolute path, excluding the domain name. Example: '/events/search/'.", max_length=512, verbose_name='redirect from', db_index=True),
         ),
     ]

--- a/regex_redirects/migrations/0005_auto_20210425_1321.py
+++ b/regex_redirects/migrations/0005_auto_20210425_1321.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('regex_redirects', '0004_auto_20170512_1349'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='redirect',
+            name='old_path',
+            field=models.CharField(db_index=True, help_text="This should be an absolute path, excluding the domain name. Example: '/events/search/'.", max_length=512, verbose_name='redirect from'),
+        ),
+    ]

--- a/regex_redirects/models.py
+++ b/regex_redirects/models.py
@@ -6,7 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 
 class Redirect(models.Model):
     old_path = models.CharField(_('redirect from'),
-                                max_length=2000,
+                                max_length=512,
                                 db_index=True,
                                 help_text=_("This should be an absolute path, excluding the domain name. Example: '/events/search/'."))
     new_path = models.CharField(_('redirect to'),


### PR DESCRIPTION
- MariaDB can create index for vartext columns only if the total
  maximum length does not exceed 3072 bytes. When using latin1, this
  translated into column max length of 3072. However, when using more
  complex encoding types, this can be substantially less. In case of
  utf8mb4 encoding the maximum is 4 times less, since a single
  character may require as much as 4 bytes to encode (768).
- Limit the maximum length for the old_path field to 512
  characters. This should be more than sufficient for most redirects.
- Changes made to an older migration for simplicity sake - this should
  cover issues on new installations, while new migration should handle
  existing installations.