### PR TITLE
Use an atomic increment for nr_times_visited

### DIFF
--- a/regex_redirects/middleware.py
+++ b/regex_redirects/middleware.py
@@ -1,9 +1,14 @@
 import re
+import logging
 
 from django import http
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
+from django.db import transaction
+from django.db.models.expressions import F
+
+logger = logging.getLogger(__name__)
 
 from .models import Redirect
 
@@ -34,9 +39,19 @@ class RedirectFallbackMiddleware(MiddlewareMixin):
         super(RedirectFallbackMiddleware, self).__init__(*args, **kwargs)
 
     def increment_redirect(self, pk):
-        redirect = Redirect.objects.get(pk=pk)
-        redirect.nr_times_visited += 1
-        redirect.save()
+        def increment():
+            try:
+                Redirect.objects.filter(pk=pk).update(
+                    nr_times_visited=F("nr_times_visited") + 1
+                )
+            except Exception:
+                logger.warning("Increment nr_times_visited failed.")
+                raise
+
+        # https://docs.djangoproject.com/en/5.1/topics/db/transactions/#performing-actions-after-commit
+        # All errors derived from Python’s Exception class are caught and logged to the
+        # django.db.backends.base logger.
+        transaction.on_commit(increment)
 
     def process_response(self, request, response):
         if response.status_code != 404:

--- a/regex_redirects/middleware.py
+++ b/regex_redirects/middleware.py
@@ -1,5 +1,5 @@
-import re
 import logging
+import re
 
 from django import http
 from django.conf import settings
@@ -8,9 +8,10 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
 from django.db.models.expressions import F
 
+from .models import Redirect
+
 logger = logging.getLogger(__name__)
 
-from .models import Redirect
 
 try:
     from django.utils.deprecation import MiddlewareMixin

--- a/regex_redirects/tests.py
+++ b/regex_redirects/tests.py
@@ -22,7 +22,9 @@ class RegexRedirectTests(TestCase):
     def test_redirect(self):
         redirect = Redirect.objects.create(old_path="/initial", new_path="/new_target")
         self.assertEqual(redirect.nr_times_visited, 0)
-        response = self.client.get("/initial")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.get("/initial")
+        self.assertEqual(len(callbacks), 1)
         self.assertRedirects(
             response, "/new_target", status_code=301, target_status_code=404
         )
@@ -35,7 +37,9 @@ class RegexRedirectTests(TestCase):
             old_path="/initial/", new_path="/new_target/"
         )
         self.assertEqual(redirect.nr_times_visited, 0)
-        response = self.client.get("/initial")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.get("/initial")
+        self.assertEqual(len(callbacks), 1)
         self.assertRedirects(
             response, "/new_target/", status_code=301, target_status_code=404
         )
@@ -51,12 +55,14 @@ class RegexRedirectTests(TestCase):
         )
 
     def test_regular_expression(self):
-        redirect = Redirect.objects.create(
+        Redirect.objects.create(
             old_path=r"/news/index/(\d+)/(.*)/",
             new_path="/my/news/$2/",
             regular_expression=True,
         )
-        response = self.client.get("/news/index/12345/foobar/")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.get("/news/index/12345/foobar/")
+        self.assertEqual(len(callbacks), 1)
         self.assertRedirects(
             response, "/my/news/foobar/", status_code=301, target_status_code=404
         )

--- a/testsettings.py
+++ b/testsettings.py
@@ -22,7 +22,7 @@ MIDDLEWARE = ["regex_redirects.middleware.RedirectFallbackMiddleware"]
 
 SITE_ID = 1
 
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Django seems to require a ROOT_URLCONF.
 ROOT_URLCONF = __name__

--- a/testsettings.py
+++ b/testsettings.py
@@ -22,6 +22,8 @@ MIDDLEWARE = ["regex_redirects.middleware.RedirectFallbackMiddleware"]
 
 SITE_ID = 1
 
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
 # Django seems to require a ROOT_URLCONF.
 ROOT_URLCONF = __name__
 urlpatterns = []


### PR DESCRIPTION
This update uses an update query with an F expression to atomically increment `nr_times_visited`. The update query is run using to `transaction.on_commit` to ensure that the value is only incremented when the current transaction succeeds (`transaction.on_commit` calls the function immediately if there is no transaction).

I also set `DEFAULT_AUTO_FIELD` to `BigAutoField` to silence the warning when running the tests.

Feedback is appreciated. Feel free to also edit the PR if there are changes you want to make. 